### PR TITLE
Remove PLUGIN-CHECKSUM include

### DIFF
--- a/eduadmin.php
+++ b/eduadmin.php
@@ -361,7 +361,6 @@ if ( ! class_exists( 'EduAdmin' ) ) :
 		private function includes() {
 			$t = $this->start_timer( __METHOD__ );
 
-			include_once 'libraries/plugin-checksum.php';
 			include_once 'libraries/EDURequestCache.php';
 			include_once 'class/class-eduadminrouter.php';
 			$this->router = new EduAdminRouter();

--- a/src/eduadmin.php
+++ b/src/eduadmin.php
@@ -89,10 +89,6 @@ if ( ! class_exists( 'EduAdmin' ) ) :
 		public $short_months;
 		/** @var array */
 		public $request_items;
-		/** @var string */
-		private $storedIntegrityHash;
-		/** @var string */
-		private $currentIntegrityHash;
 		/** @var boolean */
 		public $api_connection;
 


### PR DESCRIPTION
Remove PLUGIN-CHECKSUM include to fix output when using CLI tools like WP-CLI